### PR TITLE
Revert "Added talk title for today's CnC"

### DIFF
--- a/2018/cupcakes_and_coding_presenters_2018.csv
+++ b/2018/cupcakes_and_coding_presenters_2018.csv
@@ -4,7 +4,7 @@ date,presenter,github_username,topic
 2018-06-12,Bing Wu,bingwu2017,Launching AWS instances with aegea
 2018-06-19,Eric Waltari,ewaltari,Using the `github.com/czbiohub/utilities` tools to align and count RNA-seq data
 2018-06-26,Vedran Hadziosmanovic,Vedranh13,Introduction to deep learning
-2018-07-03,Amy Kistler,amykczb,Intro to basic de novo assembly with PRICE
+2018-07-03,Amy Kistler,amykczb,
 2018-07-10,John Pak,pakjohn1,
 2018-07-17,Michelle Tan,themichelletan,
 2018-07-24,Gerry Meixiong,,


### PR DESCRIPTION
Reverts czbiohub/cupcakes#7

Hey the talk titles are auto generated from this spreadsheet: https://docs.google.com/spreadsheets/d/18q2DPYSSDeqT8F2QqUs7pCm-23fhyvPn2XRkczbnXOo/edit#gid=0 so I'm reverting this commit